### PR TITLE
Handle object type

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ from mistyPy.Robot import Robot
 from mistyPy.Events import Events
 ```
 
-There are then two ways of interacting with the events. The first is to use a callback function for every new message returned after the successful subscribtion, the second is to reference the event object itself.
+There are then two ways of interacting with the events. The first is to use a callback function for every new message returned after the successful subscription, the second is to reference the event object itself.
 By default all event registrations are set to trigger once then unregister. To set an event registration to constantly trigger use the `keep_alive` parameter and set it to `True`.
 
 Example: 

--- a/mistyPy/GenerateRobot.py
+++ b/mistyPy/GenerateRobot.py
@@ -84,7 +84,8 @@ class Command:
             "Byte[]": "bytes",
             "Byte": "bytes",
             "Single": "float",
-            "GridCell": "GridCell"
+            "GridCell": "GridCell",
+            "Object": "object"
         }
 
         parsed_args = []

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ requires = [
 setup(
   name = 'Misty-SDK',
   packages = ['mistyPy'],
-  version = '0.1.1',
+  version = '0.1.2',
   license='apache-2.0',
   description = 'Python SDK for Misty 2 Robots',
   long_description=long_description,
@@ -31,6 +31,7 @@ setup(
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
+	'Programming Language :: Python :: 3.10',
   ],
   project_urls={'Documentation': 'https://docs.mistyrobotics.com/',
   'Source': 'https://github.com/MistyCommunity/Python-SDK',

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
-	'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.10',
   ],
   project_urls={'Documentation': 'https://docs.mistyrobotics.com/',
   'Source': 'https://github.com/MistyCommunity/Python-SDK',


### PR DESCRIPTION
Misty now uses an 'Object' type in its API and the prior Python SDK didn't handle it. So adding it now.